### PR TITLE
fix: 为 createServerTokenAuthentication 添加 statesHook 类型

### DIFF
--- a/src/service/http/alova.ts
+++ b/src/service/http/alova.ts
@@ -1,5 +1,5 @@
 import { createAlova } from 'alova'
-import VueHook from 'alova/vue'
+import VueHook, { type VueHookType } from 'alova/vue'
 import adapterFetch from 'alova/fetch'
 import { createServerTokenAuthentication } from 'alova/client'
 import {
@@ -14,7 +14,7 @@ import {
 } from './config'
 import { local } from '@/utils'
 
-const { onAuthRequired, onResponseRefreshToken } = createServerTokenAuthentication({
+const { onAuthRequired, onResponseRefreshToken } = createServerTokenAuthentication<VueHookType>({
   // 服务端判定token过期
   refreshTokenOnSuccess: {
     // 当服务端返回401时，表示token过期


### PR DESCRIPTION
> 参考文档：https://alova.js.org/zh-CN/tutorial/client/strategy/token-authentication#typescript

未指定 `createServerTokenAuthentication` 的 `statesHook` 类型时，使用 `useRequest` 无法正确推导 data 的类型。
（不过现在 alova 的 v3 版本有 bug，具体 [issue](https://github.com/alovajs/alova/issues/493)

