### PR TITLE
fix: quill dark mode

### DIFF
--- a/src/components/custom/Editor/RichTextEditor/index.vue
+++ b/src/components/custom/Editor/RichTextEditor/index.vue
@@ -105,3 +105,14 @@ onBeforeUnmount(() => editorInst = null)
 <template>
   <div ref="editorRef" />
 </template>
+
+<style>
+html.dark .ql-editor,
+html.dark .ql-toolbar .ql-picker,
+html.dark .ql-toolbar .ql-stroke,
+html.dark .ql-toolbar .ql-fill {
+  color: #FFFFFFD1;
+  stroke: #FFFFFFD1;
+  fill: #FFFFFFD1;
+}
+</style>


### PR DESCRIPTION
<img width="867" alt="image" src="https://github.com/user-attachments/assets/4613a8b4-94a7-408d-9d37-ba98c370e864">

Fix the abnormal display of the toolbar in the editor in dark mode.
---
修复编辑器在深色模式下工具栏的异常显示