### PR TITLE
fix: add the autocomplete attribute to the username/password input.

### DIFF
--- a/src/views/build-in/login/components/Login/index.vue
+++ b/src/views/build-in/login/components/Login/index.vue
@@ -70,10 +70,10 @@ function checkUserAccount() {
     </n-h2>
     <n-form ref="formRef" :rules="rules" :model="formValue" :show-label="false" size="large">
       <n-form-item path="account">
-        <n-input v-model:value="formValue.account" clearable :placeholder="$t('login.accountPlaceholder')" />
+        <n-input v-model:value="formValue.account" clearable :placeholder="$t('login.accountPlaceholder')" :input-props="{autocomplete:'username'}" />
       </n-form-item>
       <n-form-item path="pwd">
-        <n-input v-model:value="formValue.pwd" type="password" :placeholder="$t('login.passwordPlaceholder')" clearable show-password-on="click">
+        <n-input v-model:value="formValue.pwd" type="password" :placeholder="$t('login.passwordPlaceholder')" clearable show-password-on="click" :input-props="{autocomplete:'current-password'}" >
           <template #password-invisible-icon>
             <icon-park-outline-preview-close-one />
           </template>

--- a/src/views/build-in/login/components/Register/index.vue
+++ b/src/views/build-in/login/components/Register/index.vue
@@ -49,6 +49,7 @@ function handleRegister() {}
           v-model:value="formValue.account"
           clearable
           :placeholder="$t('login.accountPlaceholder')"
+          :input-props="{autocomplete:'username'}"
         />
       </n-form-item>
       <n-form-item path="pwd">
@@ -58,6 +59,7 @@ function handleRegister() {}
           :placeholder="$t('login.passwordPlaceholder')"
           clearable
           show-password-on="click"
+          :input-props="{autocomplete:'new-password'}"
         >
           <template #password-invisible-icon>
             <icon-park-outline-preview-close-one />
@@ -74,6 +76,7 @@ function handleRegister() {}
           :placeholder="$t('login.checkPasswordPlaceholder')"
           clearable
           show-password-on="click"
+          :input-props="{autocomplete:'new-password'}"
         >
           <template #password-invisible-icon>
             <icon-park-outline-preview-close-one />


### PR DESCRIPTION
登录和注册 输入框增加对应的 autocomplete 属性，语义化提示 谷歌浏览器 唤起 "记住密码"、"更新密码"。

同时避免调试模式下收到下面的警告信息：

```
[DOM] Input elements should have autocomplete attributes (suggested: "username"): (More info: https://goo.gl/9p2vKq) 
```

```
[DOM] Input elements should have autocomplete attributes (suggested: "new-password"): (More info: https://goo.gl/9p2vKq)
```

```
[DOM] Input elements should have autocomplete attributes (suggested: "current-password"): (More info: https://goo.gl/9p2vKq)
```